### PR TITLE
added wiki reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ ATS-Postiats-contrib
 ====================
 
 ATS-Postiats-contrib is primarily for packages contributed to ATS-Postiats
+
+More information can be [found on the ATS2 wiki](https://github.com/githwxi/ATS-Postiats/wiki/contrib).
+Descriptions of packages in ATS-Postiats-contrib may also be found in various articles on the wiki.
+
+


### PR DESCRIPTION
For instance, for the second point, there is now https://github.com/githwxi/ATS-Postiats/wiki/Scientific-Computing
But there may be others
