### PR TITLE
ATS-paremit: adding dynload0 support.

### DIFF
--- a/projects/MEDIUM/ATS-parse-emit/Python/atsparemit_emit_python.dats
+++ b/projects/MEDIUM/ATS-parse-emit/Python/atsparemit_emit_python.dats
@@ -1009,6 +1009,15 @@ ins0.instr_node of
     val () = emit_i0de (out, tmp2)
   } (* end of [ATSINSargmove_tlcal] *)
 //
+| ATSdynload0 (tmp) =>
+  {
+    val () = emit_nspc (out, ind)   
+    val () = emit_text (out, "ATSdynload0")
+    val () = emit_LPAREN (out)
+    val () = emit_i0de (out, tmp)
+    val () = emit_RPAREN (out)
+  }
+//
 | ATSdynload1 (tmp) =>
   {
     val () = emit_nspc (out, ind)   

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit.sats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit.sats
@@ -231,6 +231,7 @@ keyword =
 //
   | ATSINSdeadcode_fail of ()
 //
+  | ATSdynload0 of ()
   | ATSdynload1 of ()
   | ATSdynloadset of ()
 //
@@ -783,6 +784,7 @@ instr_node =
 //
   | ATSINSdeadcode_fail of (token)
 //
+  | ATSdynload0 of (i0de)
   | ATSdynload1 of (i0de)
   | ATSdynloadset of (i0de)
 //

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_global.dats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_global.dats
@@ -154,6 +154,7 @@ val-~None_vt() = kwordins ("ATSINSargmove_tlcal", ATSINSargmove_tlcal)
 //
 val-~None_vt() = kwordins ("ATSINSdeadcode_fail", ATSINSdeadcode_fail)
 //
+val-~None_vt() = kwordins ("ATSdynload0", ATSdynload0)
 val-~None_vt() = kwordins ("ATSdynload1", ATSdynload1)
 val-~None_vt() = kwordins ("ATSdynloadset", ATSdynloadset)
 //

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_parsing.dats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_parsing.dats
@@ -636,7 +636,7 @@ parse_tyfld
   (buf, bt, err) = let
 //
 (*
-val () = println! ("parse_instr")
+val () = println! ("parse_tyfld")
 *)
 //
 val err0 = err

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_parsing_instr.dats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_parsing_instr.dats
@@ -420,6 +420,18 @@ tok.token_node of
     // end of [if]
   end // end of [ATSINSdeadcode_fail]  
 //
+| T_KWORD(ATSdynload0()) => let
+    val bt = 0
+    val () = incby1 ()
+    val ent1 = p_LPAREN (buf, bt, err)
+    val ent2 = pif_fun (buf, bt, err, parse_i0de, err0)
+    val ent3 = pif_fun (buf, bt, err, p_RPAREN, err0)
+    val ent4 = pif_fun (buf, bt, err, p_SEMICOLON, err0)
+  in
+    if (err = err0)
+      then ATSdynload0_make (tok, ent2, ent3) else tokbuf_set_ntok_null (buf, n0)
+  end // end of [ATSdynload0]    
+//
 | T_KWORD(ATSdynload1()) => let
     val bt = 0
     val () = incby1 ()

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_print.dats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_print.dats
@@ -145,6 +145,7 @@ case+ x of
 //
 | ATSINSdeadcode_fail () => p "ATSINSdeadcode_fail"
 //
+| ATSdynload0 () => p "ATSdynload0"
 | ATSdynload1 () => p "ATSdynload1"
 | ATSdynloadset () => p "ATSdynloadset"
 //

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_syntax.dats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_syntax.dats
@@ -788,6 +788,19 @@ end // end of [ATSINSdeadcode_fail_make]
 (* ****** ****** *)
 
 implement
+ATSdynload0_make
+  (tok1, id, tok2) = let
+//
+val loc =
+  tok1.token_loc ++ tok2.token_loc
+//
+in
+  instr_make_node (loc, ATSdynload0(id))
+end // end of [ATSdynload0]
+
+(* ****** ****** *)
+
+implement
 ATSdynload1_make
   (tok1, id, tok2) = let
 //

--- a/projects/MEDIUM/ATS-parse-emit/atsparemit_syntax.sats
+++ b/projects/MEDIUM/ATS-parse-emit/atsparemit_syntax.sats
@@ -326,6 +326,8 @@ ATSINSdeadcode_fail_make (tok_kwd: token, tok_end: token): instr
 (* ****** ****** *)
 
 fun
+ATSdynload0_make (tok_kwd: token, id: i0de, tok_end: token): instr
+fun
 ATSdynload1_make (tok_kwd: token, id: i0de, tok_end: token): instr
 fun
 ATSdynloadset_make (tok_kwd: token, id: i0de, tok_end: token): instr


### PR DESCRIPTION
Today I tried to test what ATS-paremit will output for a simple program:

```
staload _ = "prelude/DATS/integer.dats"

implement main0 (argc, argv) = let
  val x = 10
  val y = 15
  val z = x + y
in
  println!("z = ", z)
end // end of [main]
```

However, atsparemit would end up complaining about some EOF which isn't quite there. So, turned out that the utility didn't know of ATSdynload0 instruction. This is what this patch adds.
