### PR TITLE
needed in Cygwin

### DIFF
--- a/projects/SMALL/Calculator/calculator_parsing.dats
+++ b/projects/SMALL/Calculator/calculator_parsing.dats
@@ -25,6 +25,14 @@
 staload "./calculator.sats"
 
 (* ****** ****** *)
+//
+// Needed in Cygwin
+//
+%{^
+#include <alloca.h>
+%}
+
+(* ****** ****** *)
 
 (*
 


### PR DESCRIPTION
I think I've seen this pop up before; there may be a more general way to handle the issue. Otherwise get the following:

```
\
  "/home/brand_000/ATS-Postiats"/bin/patscc -cleanaft -I"/home/brand_000/ATS-Postiats" -I"/home/brand_000/ATS-Postiats"/ccomp/runtime -I"/home/brand_000/ATS-Postiats-contrib"/contrib -IATS "/home/brand_000/ATS-Postiats-contrib"/contrib -DATS_MEMALLOC_LIBC -D_GNU_SOURCE -O2 -o calculator_mylib_dats.o -c calculator_mylib.dats
In file included from calculator_mylib_dats.c:33:0:
/home/brand_000/ATS-Postiats/prelude/CATS/char.cats: In function ‘atspre_isascii_int’:
/home/brand_000/ATS-Postiats/prelude/CATS/char.cats:405:3: warning: implicit declaration of function ‘isascii’ [-Wimplicit-function-declaration]
   return (isascii(c) ? atsbool_true : atsbool_false) ;
   ^
\
  "/home/brand_000/ATS-Postiats"/bin/patscc -I"/home/brand_000/ATS-Postiats" -I"/home/brand_000/ATS-Postiats"/ccomp/runtime -I"/home/brand_000/ATS-Postiats-contrib"/contrib -D_GNU_SOURCE -O2 -o calc calculator_sats.o calculator_dats.o calculator_aexp_dats.o calculator_token_dats.o calculator_cstream_dats.o calculator_tstream_dats.o calculator_parsing_dats.o calculator_print_dats.o calculator_mylib_dats.o
calculator_parsing_dats.o:calculator_parsing_dats.c:(.text+0x5c4): undefined reference to `alloca'
calculator_parsing_dats.o:calculator_parsing_dats.c:(.text+0x5c4): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `alloca'
collect2: error: ld returned 1 exit status
/home/brand_000/ATS-Postiats/share/atsmake-post.mk:33: recipe for target 'calc' failed
make: *** [calc] Error 1
```

EDIT: the solution is to use `-D_XOPEN_SOURCE`, e.g:

```
PATSCCOMP = $(CC) -D_XOPEN_SOURCE
```
