### PR TITLE
Fixed issue with Bacon.combineWith()

### DIFF
--- a/contrib/libatscc/libatscc2js/CATS/Bacon.js/baconjs_cats.js
+++ b/contrib/libatscc/libatscc2js/CATS/Bacon.js/baconjs_cats.js
@@ -114,7 +114,8 @@ ats2js_bacon_Bacon_combineWith2(xs1, xs2, f)
   var
   theCombined =
   Bacon.combineWith(
-    xs1, xs2, function(x1,x2){ return ats2jspre_cloref2_app(f, x1, x2); }
+    function(x1,x2){ return ats2jspre_cloref2_app(f, x1, x2); },
+    xs1, xs2
   ) // end of [var]
   return theCombined;
 }
@@ -125,7 +126,8 @@ ats2js_bacon_Bacon_combineWith3(xs1, xs2, xs3, f)
   var
   theCombined =
   Bacon.combineWith(
-    xs1, xs2, xs3, function(x1,x2,x3){ return ats2jspre_cloref3_app(f, x1, x2, x3); }
+    function(x1,x2,x3){ return ats2jspre_cloref3_app(f, x1, x2, x3); },
+    xs1, xs2, xs3
   ) // end of [var]
   return theCombined;
 }


### PR DESCRIPTION
The function is now placed first in the call to `combineWith()`, as specified by the Bacon.js API.

As I’m new to contributing changes to this repository, please feel tree to close this pull request if I’ve done something wrong.