### PR TITLE
solver_smt.dats: Don't use mapfree on linear list of non-linear values

### DIFF
--- a/projects/MEDIUM/ATS-extsolve/main.dats
+++ b/projects/MEDIUM/ATS-extsolve/main.dats
@@ -34,7 +34,7 @@ dynload "commarg.dats"
 
 (* ****** ****** *)
 
-overload mapfree with list_vt_mapfree
+overload map with list_vt_map
 overload filter with list_vt_filter
 
 (* ****** ****** *)
@@ -56,12 +56,13 @@ implement main0 (argc, argv) = let
       | Script (s) => true
       | _ =>> false
   implement
-  list_vt_mapfree$fopr<commarg><string> (x) =
+  list_vt_map$fopr<commarg><string> (x) =
     case- x of
       | Script (s) => s
   //
   val scriptargs = filter (list_vt_copy (args))
-  val scripts = mapfree<commarg><string> (scriptargs)
+  val scripts = map<commarg><string> (scriptargs)
+  val () = list_vt_free (scriptargs)
   //
   implement
   list_find$pred<commarg> (x) =

--- a/projects/MEDIUM/ATS-extsolve/solving/solver_smt.dats
+++ b/projects/MEDIUM/ATS-extsolve/solving/solver_smt.dats
@@ -348,7 +348,7 @@ in
         //
         val () = assertloc (length(pairs) > 0)
         //
-        implement list_vt_mapfree$fopr<@(s2exp,s2exp)><formula>(x) = let
+        implement list_vt_map$fopr<@(s2exp,s2exp)><formula>(x) = let
           val (pf, fpf | Env) = $UN.ptr1_vtake{smtenv}(addr@ env)
           val met = formula_make (!Env, x.0)
           val bound = formula_make (!Env, x.1)
@@ -362,7 +362,8 @@ in
         end
         //
         val assertions =
-          list_vt_mapfree<(s2exp,s2exp)><formula> (pairs)
+          list_vt_map<(s2exp,s2exp)><formula> (pairs)
+        val () = list_vt_free(pairs)
         //
         implement 
         list_vt_fold$init<formula><formula> (x) = x


### PR DESCRIPTION
@githwxi  without this, I get:

> solving/solver_smt.dats: 9617(line=359, offs=13) -- 9646(line=359, offs=42): error(3): the linear dynamic variable [x$view$5402(-1)] is preserved but with an incompatible type.

I'm confused though, as the input list element type is non-linear. Is there some way to use `mapfree` when the input list has a non-linear element type?